### PR TITLE
Make Tk-based tests headless-friendly

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,0 +1,27 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+
+@pytest.fixture
+def tk_root():
+    """Provide a Tk root window or skip tests when no display is available."""
+    import tkinter as tk
+
+    try:
+        root = tk.Tk()
+    except tk.TclError:
+        pytest.skip("Tkinter requires a display to run these tests")
+
+    root.withdraw()
+
+    try:
+        yield root
+    finally:
+        root.destroy()

--- a/test/test_CollageTree.py
+++ b/test/test_CollageTree.py
@@ -1,11 +1,9 @@
 from src.CollageTree import CollageRoot, ResizableLeaf
 from src.Collage import Collage
 from src.CollageImage import safe_open_image
-from src.scroll import ScrolledFrame
 
 import pytest
 import os
-import tkinter as tk
 
 
 @pytest.fixture
@@ -14,9 +12,12 @@ def filename():
 
 
 @pytest.fixture
-def collage():
-    collage = Collage(0, 1, 1, 1, None, [], {'width': 30, 'height': 30})
-    return collage
+def collage(tk_root):
+    collage = Collage(0, 1, 1, 1, None, [tk_root], {'width': 30, 'height': 30})
+    try:
+        yield collage
+    finally:
+        collage.destroy()
 
 
 @pytest.fixture

--- a/test/test_PILCollageImage.py
+++ b/test/test_PILCollageImage.py
@@ -1,10 +1,7 @@
-import tkinter as tk
-
 from src.Collage import Collage
 from src.CollageImage import PILCollageImage
 from src.CornerCreator import CornerCreator
 from src.CollageImage import safe_open_image
-from src.scroll import ScrolledFrame
 
 import pytest
 import os
@@ -16,9 +13,12 @@ def filename():
 
 
 @pytest.fixture
-def collage():
-    collage = Collage(0, 1, 1, 1, None, [], {'width': 30, 'height': 30})
-    return collage
+def collage(tk_root):
+    collage = Collage(0, 1, 1, 1, None, [tk_root], {'width': 30, 'height': 30})
+    try:
+        yield collage
+    finally:
+        collage.destroy()
 
 
 @pytest.fixture

--- a/test/test_run.py
+++ b/test/test_run.py
@@ -1,15 +1,14 @@
 from src.mainwindow import Application
 from src.textconfig import TextConfigureApp
-import tkinter as tk
 
 
-def test_run_Application():
-    app = Application(master=tk.Tk())
+def test_run_Application(tk_root):
+    app = Application(master=tk_root)
     app.update()
     app.destroy()
 
 
-def test_run_TextConfigureApp():
-    app = TextConfigureApp(master=tk.Tk())
+def test_run_TextConfigureApp(tk_root):
+    app = TextConfigureApp(master=tk_root)
     app.update()
     app.destroy()


### PR DESCRIPTION
## Summary
- add a shared pytest fixture that injects the repository root into `sys.path` and provides a Tk root or skips when no display is available
- update Tk-dependent tests to consume the fixture so they no longer fail in headless environments

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68ceb2576b0c8333a2078f0a032d1da1